### PR TITLE
adding BaseClass to comments

### DIFF
--- a/code/WordpressCommentImport.php
+++ b/code/WordpressCommentImport.php
@@ -20,6 +20,7 @@ class WordpressCommentImport extends Extension {
 			$c->Name = (string) $comment->comment_author;
 			$c->Email = (string) $comment->comment_author_email;
 			$c->URL = (string) $comment->comment_author_url;
+			$c->BaseClass = (string) "SiteTree";
 			$c->Comment = (string) $comment->comment_content;
 			$c->Created = (string) $comment->comment_date;
 			$c->Moderated = !!$comment->comment_approved;


### PR DESCRIPTION
Hi @camfindlay this change adds baseclass 'SiteTree' to the comments during import. This means comments from WP can will be handled properly through the comments module. 