### PR TITLE
removed nl2br

### DIFF
--- a/code/WordpressImporter.php
+++ b/code/WordpressImporter.php
@@ -601,9 +601,6 @@ class WordpressImporter extends Object {
 			else
 				$content .= "<p>$paragraph</p>";
 		}
-		
-		// Split single-line blocks with line-breaks
-		$content = nl2br($content);
 
 		return $content;
 	}

--- a/code/WpParser.php
+++ b/code/WpParser.php
@@ -108,9 +108,6 @@ class WpParser
                 $content .= "<p>$paragraph</p>";
             }
         }
-        
-        // Split single-line blocks with line-breaks
-        $content = nl2br($content);
 
         return $content;
     }


### PR DESCRIPTION
@camfindlay 

This change removes two instances nl2br. 

We removed nl2br because it messed up the formatting - was adding in a new line every time there was a break from a table for example - resulting in a lot of white space